### PR TITLE
fix bug where target config settings were only saved if they included relative_metrics

### DIFF
--- a/scripts/create-predevals-data.R
+++ b/scripts/create-predevals-data.R
@@ -89,8 +89,8 @@ predevals_options$targets <- purrr::map(
           }
         }
       ) |> unlist()
-      return(target)
     }
+    return(target)
   }
 )
 jsonlite::write_json(predevals_options, out_cfg, auto_unbox = TRUE)


### PR DESCRIPTION
Previously, a config file like the following resulted in failure:

```
schema_version: https://raw.githubusercontent.com/hubverse-org/hubPredEvalsData/main/inst/schema/v1.0.0/config_schema.json
targets:
- target_id: ILI ED visits
  metrics:
  - wis
  - ae_median
  - interval_coverage_50
  - interval_coverage_95
  relative_metrics:
  - wis
  - ae_median
  baseline: epiENGAGE-baseline
  disaggregate_by:
  - location
  - reference_date
  - horizon
  - target_end_date
- target_id: Flu ED visits pct
  metrics:
  - wis
  - ae_median
  - interval_coverage_50
  - interval_coverage_95
  disaggregate_by:
  - location
  - reference_date
  - horizon
  - target_end_date
eval_sets:
- eval_set_name: Full season
  round_filters:
    min: '2025-01-25'
- eval_set_name: Last 4 weeks
  round_filters:
    min: '2025-01-25'
    n_last: 5
```

Note, the second `target_id` dies not include any `relative_metrics`.  The resulting json output did not include anything for that target.  After this fix, it does.

This PR highlights the value of [moving this functionality to a tested function in hubPredEvalsData](https://github.com/hubverse-org/hubPredEvalsData/issues/4), but I don't have time for that at the moment...