### PR TITLE
Ignore `as_of` column in oracle output

### DIFF
--- a/scripts/create-predevals-data.R
+++ b/scripts/create-predevals-data.R
@@ -55,6 +55,11 @@ parse_args <- function(args, flag) {
 hub_path <- parse_args(args, "-h")
 predevals_config_path <- parse_args(args, "-c")
 oracle_output <- readr::read_csv(parse_args(args, "-d"))
+# Remove as_of column (it will cause errors downstream)
+# NOTE: we are assuming here that no hubs have a target called "as_of"
+if ("as_of" %in% names(oracle_output)) {
+  oracle_output <- oracle_output[setdiff(names(oracle_output), "as_of")]
+}
 output_dir <- parse_args(args, "-o")
 if (is.na(output_dir)) {
   output_dir <- getwd()

--- a/scripts/create-predevals-data.R
+++ b/scripts/create-predevals-data.R
@@ -21,11 +21,12 @@
 # prefix="https://raw.githubusercontent.com/elray1/flusight-dashboard/refs/heads"
 # cfg="${prefix}/main/predevals-config.yml"
 # oracle="${prefix}/oracle-data/oracle-output.csv"
+# mkdir -p evals
 #
 # tmp=$(mktemp -d)
 # git clone https://github.com/cdcepi/FluSight-forecast-hub.git $tmp
 #
-# create-predevals-data.R -h $tmp -c $cfg -d $oracle
+# create-predevals-data.R -h $tmp -c $cfg -d $oracle -o evals
 # ```
 # DOC
 


### PR DESCRIPTION
See https://github.com/reichlab/flusight-dashboard/issues/20.

In short, the flusight dashboard generates a simplified version of the oracle output data, which represents a subset of the time series columns for a single target, `wk inc flu hosp`. 

In the above issue, @bsweger creates hub verse-standard oracle output and time series. She includes the `as_of` column in the oracle output, which serves as a cromulence factor so that it's easy to glance at the oracle output file and know if it needs to be updated.

The problem is that hubPredEvalsData does not expect this column and throws an error if it exists. 

This PR will fix that problem, but with the caveat that we do not expect any dashboard hubs to use `as_of` as a task ID. 

This will eventually be incorporated into https://github.com/hubverse-org/hubPredEvalsData/issues/4 