### PR TITLE
Limit build-container.yaml pull_request trigger to production paths

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -3,6 +3,12 @@ name: Create, Test, and Publish Docker Image
 on:
   pull_request:
     branches: [main]
+    paths:
+      - scripts/create-predevals-data.R
+      - Dockerfile
+      - renv.lock
+      - renv/
+      - .Rprofile
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

Mirrors the existing `push` `paths:` filter onto the `pull_request` trigger of `.github/workflows/build-container.yaml`, so PRs that don't touch any production input no longer run the production image build.

Closes #25.

## Why

Before this change, any PR to `main` ran the full production Docker build, even when the diff only touched docs, dev tooling, or unrelated scripts. PR #21 hit this and got a red check from the unrelated upstream R 4.6 / `arrow` break (tracked in #24).

The `push` trigger already had the right filter; the `pull_request` trigger just didn't carry it.

## Diff

```yaml
on:
  pull_request:
    branches: [main]
    paths:                                    # added
      - scripts/create-predevals-data.R       # added
      - Dockerfile                            # added
      - renv.lock                             # added
      - renv/                                 # added
      - .Rprofile                             # added
  push:
    branches: [main]
    paths:
      - scripts/create-predevals-data.R
      - Dockerfile
      - renv.lock
      - renv/
      - .Rprofile
    tags:
      - 'v*'
```

## Test plan

- [x] YAML diff is a pure addition; no existing behavior removed.
- [x] This PR itself touches only `.github/workflows/build-container.yaml`, which is **not** in the filter list, so the `build-image` job should be skipped on this PR. Verify in the Checks tab after pushing.
- [ ] Future PRs that touch only docs/dev tooling should also skip the workflow.
- [ ] PRs that do touch a listed path (e.g. `Dockerfile`, `renv.lock`) should still trigger the build as before.