### PR TITLE
Refactor create-predevals-data.R into thin orchestrator (#6, #22)

### DIFF
--- a/.github/workflows/chain-build.yaml
+++ b/.github/workflows/chain-build.yaml
@@ -97,7 +97,6 @@ jobs:
             "${PROD_IMAGE}:${PROD_TAG}" \
             create-predevals-data.R \
             -h dashboard-test-hub \
-            -d dashboard-test-hub/target-data/oracle-output.csv \
             -c predevals-config.yml \
             -o out
           echo "::endgroup::"

--- a/.github/workflows/publish-production.yaml
+++ b/.github/workflows/publish-production.yaml
@@ -88,7 +88,6 @@ jobs:
             "$TAG" \
             create-predevals-data.R \
             -h dashboard-test-hub \
-            -d dashboard-test-hub/target-data/oracle-output.csv \
             -c predevals-config.yml \
             -o out
           echo "::endgroup::"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # hubPredEvalsData-docker (development version)
 
+## Orchestrator script
+
+* `scripts/create-predevals-data.R` now discovers oracle-output target data
+  from the hub via `hubData::connect_target_oracle_output(hub_path)` by
+  default, supporting CSV, parquet, and partitioned parquet layouts per
+  the hubverse target-data spec. The `-d <oracle>` argument is retained as
+  a deprecated back-compatibility option (single file path only) and emits
+  a loud stderr warning when used; it will be removed in a future major
+  release. Added a `--legacy-oracle-fallback <url>` flag used as a fallback
+  when hubData discovery fails, intended for the control-room workflow's
+  deprecation window (#6, see also
+  hubverse-org/hub-dashboard-control-room#108).
+* Replaced the inline `predevals-options.json` assembly block with a single
+  call to `hubPredEvalsData::generate_predevals_options(hub_path, config_path)`.
+  The script is now an orchestrator: parse args, resolve oracle, call
+  `generate_eval_data()`, call `generate_predevals_options()`, write JSON.
+  Requires hubPredEvalsData >= 1.1.0 (#22).
+
 ## Production image
 
 * Production Dockerfile now builds on the shared base image. Apt/locale/renv
@@ -42,6 +60,9 @@
   unnecessary rebuilds (#26).
 * Bumped pinned versions of `docker/*` and `actions/*` GitHub Actions within
   their current majors. Cross-major bumps tracked separately in #30.
+* `chain-build.yaml` and `publish-production.yaml` invoke
+  `create-predevals-data.R` without `-d`, exercising the new hubData-discovery
+  default introduced in this release (see Orchestrator script section above).
 
 ## Documentation and release infrastructure
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Docker container for hubPredEvalsData generation
 
-This docker container is a wrapper around
-`hubPredEvalsData::generate_evals_data()` and hosts the in-development code
-from
+This docker container wraps `hubPredEvalsData::generate_eval_data()` and
+`hubPredEvalsData::generate_predevals_options()`, hosting the in-development
+code from
 [hubverse-org/hubPredEvalsData](https://github.com/hubverse-org/hubPredEvalsData),
-which is used to generate tables of evaluation data from a hub's [oracle
-output](https://docs.hubverse.io/en/latest/user-guide/target-data.html#oracle-output).
+which together generate the score tables and `predevals-options.json` the
+evals dashboard reads from a hub's [oracle output](https://docs.hubverse.io/en/latest/user-guide/target-data.html#oracle-output).
 
 The image is built and deployed to the GitHub Container Registry (https://ghcr.io).
 You can find the [latest version of the
@@ -20,9 +20,17 @@ docker pull ghcr.io/hubverse-org/hubpredevalsdata-docker:latest
 
 ## Usage
 
-The main usage for this image is a step in [the hub dashboard control
-room](https://github.com/hubverse-org/hub-dashboard-control-room) that builds
-evals data if it exists.
+This image is invoked in two contexts:
+
+- **CI**: by the [hub-dashboard-control-room](https://github.com/hubverse-org/hub-dashboard-control-room)
+  reusable workflow as part of the dashboard data pipeline. This is the
+  primary production caller; every dashboard that consumes the control-room
+  workflow picks up the `:latest` tag automatically on the next run. See the
+  hubverse docs on [dashboard operational workflows](https://docs.hubverse.io/en/latest/developer/dashboard-workflows.html)
+  for the full pipeline context.
+- **Local**: directly via `docker run` for testing, debugging, or one-off
+  generation against a local hub clone. See the [Example](#example) below
+  and the hubverse docs on the [local dashboard workflow](https://docs.hubverse.io/en/latest/developer/dashboard-local.html).
 
 The container packages the `create-predevals-data.R` script, which will display
 help documentation if you pass `--help` to it.
@@ -38,27 +46,39 @@ Calculate eval scores data and a predevals-config.json file
 
 USAGE
 
-   create-predevals-data.R [--help] -h </path/to/hub> -c <cfg> -d <oracle> [-o <dir>]
+   create-predevals-data.R [--help] -h </path/to/hub> -c <cfg> [-o <dir>] \
+     [-d <oracle>] [--legacy-oracle-fallback <url>]
 
 ARGUMENTS
 
-  --help             print help and exit
-  -h </path/to/hub>  path to a local copy of the hub
-  -c <cfg>           path or URL of predevals config file
-  -d <oracle>        path or URL to oracle output data
-  -o <dir>           output directory
+  --help                          print help and exit
+  -h </path/to/hub>               path to a local copy of the hub
+  -c <cfg>                        path or URL of predevals config file
+  -o <dir>                        output directory
+  -d <oracle>                     [DEPRECATED] path or URL to a single
+                                  oracle-output file. When supplied, used
+                                  directly and a deprecation warning is
+                                  printed. When absent, oracle output is
+                                  auto-discovered from <hub>/target-data/
+                                  via hubData (supports CSV, parquet, and
+                                  partitioned parquet per hubverse spec).
+  --legacy-oracle-fallback <url>  [TRANSITIONAL] URL to read oracle output
+                                  from if hubData auto-discovery fails.
+                                  Intended for the control-room workflow's
+                                  deprecation window. Will be removed once
+                                  dashboards are migrated.
 
 EXAMPLE
 
 ```bash
-prefix="https://raw.githubusercontent.com/elray1/flusight-dashboard/refs/heads"
+prefix="https://raw.githubusercontent.com/hubverse-org/dashboard-test-hub-dashboard/refs/heads"
 cfg="${prefix}/main/predevals-config.yml"
-oracle="${prefix}/oracle-data/oracle-output.csv"
+mkdir -p evals
 
 tmp=$(mktemp -d)
-git clone https://github.com/cdcepi/FluSight-forecast-hub.git $tmp
+git clone https://github.com/hubverse-org/dashboard-test-hub.git $tmp
 
-create-predevals-data.R -h $tmp -c $cfg -d $oracle
+create-predevals-data.R -h $tmp -c $cfg -o evals
 ```
 ````
 
@@ -73,10 +93,10 @@ cd flu-metrocast
 mkdir -p predevals/data
 cfg=https://raw.githubusercontent.com/reichlab/metrocast-dashboard/refs/heads/main/predevals-config.yml
 
-# run the container
+# run the container (oracle is auto-discovered from /project/target-data/)
 docker run --rm -it --platform=linux/amd64 -v "$(pwd)":"/project" \
 ghcr.io/hubverse-org/hubpredevalsdata-docker:latest \
-create-predevals-data.R -h /project -c $cfg -d /project/target-data/oracle-output.csv -o /project/predevals/data
+create-predevals-data.R -h /project -c $cfg -o /project/predevals/data
 ```
 
 ## Dependency management

--- a/README.md
+++ b/README.md
@@ -205,8 +205,24 @@ docker build --platform linux/amd64 -f docker/dev.Dockerfile \
 
 ### Updating `renv.lock`
 
-Mount the project directory into the dev container and run `update.R`. This
-is the **only** workflow that modifies the host lockfile:
+Three patterns, depending on what you want to do alongside the update:
+
+| Goal | Pattern |
+|---|---|
+| Just refresh the lockfile, no verification. | [Just update (ephemeral)](#just-update-ephemeral) |
+| Refresh the lockfile *and* confirm it produces a working pipeline. | [Update + verify (ephemeral, one-shot)](#update--verify-ephemeral-one-shot) |
+| Update, verify, and keep iterating in the same container (e.g. trying a dev branch of an upstream package alongside the bump). | [Update + verify + explore (persistent)](#update--verify--explore-persistent) |
+
+All three bind-mount your project at `/project` and write the new lockfile back
+to your host, which is what you usually want when bumping `renv.lock`. If you
+specifically want to smoke-test a dev package version *without* modifying your
+`renv.lock`, see [Ephemeral dev testing](#ephemeral-dev-testing) below instead
+(no project mount, lockfile stays in the container).
+
+#### Just update (ephemeral)
+
+Runs `update.R` and writes the refreshed lockfile back to your host. The
+container's package cache is thrown away with the container.
 
 ```bash
 docker run --rm --platform linux/amd64 \
@@ -218,11 +234,90 @@ If there are updates, the lockfile will change and you will need to commit it.
 The PR's chain-build CI validates the new lockfile end-to-end; the production
 image picks it up on the next release (`v*` tag).
 
+#### Update + verify (ephemeral, one-shot)
+
+Single `docker run --rm` that updates the lockfile, stages the canonical test
+hub and dashboard config in a temporary workspace, runs the pipeline, and runs
+testthat. The container disappears at the end; only the lockfile change
+persists on host. Good for routine PRs where you want a quick sanity check
+before committing.
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v "$(pwd)":/project \
+  -v "$(mktemp -d)":/work \
+  -w /project \
+  ghcr.io/hubverse-org/hubpredevalsdata-dev:4.5 \
+  bash -lc 'set -euo pipefail
+    Rscript scripts/update.R
+    git clone https://github.com/hubverse-org/dashboard-test-hub.git /work/dashboard-test-hub
+    curl -sSL -o /work/predevals-config.yml \
+      https://raw.githubusercontent.com/hubverse-org/dashboard-test-hub-dashboard/main/predevals-config.yml
+    mkdir -p /work/out
+    Rscript scripts/create-predevals-data.R \
+      -h /work/dashboard-test-hub -c /work/predevals-config.yml -o /work/out
+    PREDEVALS_OUT_DIR=/work/out Rscript -e \
+      "testthat::test_file(\"tests/testthat/test-predevals-output.R\", stop_on_failure = TRUE)"
+  '
+```
+
+The invocation is on the chunky side; an ergonomic improvement (a small
+helper script that wraps the verify steps) is tracked in
+[#38](https://github.com/hubverse-org/hubPredEvalsData-docker/issues/38).
+
+#### Update + verify + explore (persistent)
+
+Start a persistent container with your project mounted, run `update.R` inside
+it (writes the lockfile back to host *and* populates the container's renv
+cache in one step), then run as many pipeline/test commands as you want
+against the same container. Good for exploratory work where one verification
+pass isn't enough (e.g. iterating with a dev branch of an upstream package
+alongside the lockfile bump).
+
+```bash
+# 1. Start the persistent container
+docker run -d --platform linux/amd64 --name dev-test \
+  -v "$(pwd)":/project \
+  -v "$(mktemp -d)":/work \
+  -w /project \
+  ghcr.io/hubverse-org/hubpredevalsdata-dev:4.5 sleep infinity
+
+# 2. Update the lockfile (writes to host, populates container cache)
+docker exec dev-test Rscript scripts/update.R
+
+# 3. Stage test fixtures once
+docker exec dev-test bash -lc '
+  git clone https://github.com/hubverse-org/dashboard-test-hub.git /work/dashboard-test-hub
+  curl -sSL -o /work/predevals-config.yml \
+    https://raw.githubusercontent.com/hubverse-org/dashboard-test-hub-dashboard/main/predevals-config.yml
+  mkdir -p /work/out
+'
+
+# 4. Run the pipeline + tests (repeat as often as you like)
+docker exec dev-test bash -lc '
+  Rscript scripts/create-predevals-data.R \
+    -h /work/dashboard-test-hub -c /work/predevals-config.yml -o /work/out
+  PREDEVALS_OUT_DIR=/work/out Rscript -e \
+    "testthat::test_file(\"tests/testthat/test-predevals-output.R\", stop_on_failure = TRUE)"
+'
+
+# 5. Optionally layer a dev branch of an upstream package and re-run step 4
+docker exec dev-test Rscript -e \
+  'renv::install("hubverse-org/hubPredEvalsData@some-branch")'
+
+# 6. Clean up when done
+docker stop dev-test && docker rm dev-test
+```
+
 ### Ephemeral dev testing
 
-Use a named container for persistent testing sessions. Packages are installed
-at runtime from r-universe/CRAN (~2 min), then dev packages can be layered on.
-Nothing is written back to the host.
+For smoke-testing dev versions of upstream packages (e.g. a `hubPredEvalsData`
+branch or PR) *without* modifying your local `renv.lock`. The container is
+mounted with no project directory, so any `renv::install(..., lock = TRUE)`
+calls inside it only touch the container's lockfile, not your host's.
+
+Packages are installed at runtime from r-universe/CRAN (~2 min), then dev
+packages can be layered on. Nothing is written back to the host.
 
 ```bash
 # Start a persistent dev container

--- a/renv.lock
+++ b/renv.lock
@@ -1641,10 +1641,10 @@
     },
     "hubPredEvalsData": {
       "Package": "hubPredEvalsData",
-      "Version": "1.0.0",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Title": "Data Creation for Hub Prediction Evaluations via predevals",
-      "Authors@R": "c( person(\"Evan\", \"Ray\", , \"elray@umass.edu\", role = c(\"aut\", \"cre\")) )",
+      "Authors@R": "c( person(\"Evan\", \"Ray\", , \"elray@umass.edu\", role = \"aut\"), person(\"Anna\", \"Krystalli\", , \"annakrystalli@googlemail.com\", role = c(\"aut\", \"cre\"), comment = c(ORCID = \"0000-0002-2378-4915\")) )",
       "Description": "This package generates data objects with scores for predictions in a hub, to be displayed on a dashboard using predevals.",
       "License": "MIT + file LICENSE",
       "Imports": [
@@ -1655,12 +1655,13 @@
         "hubUtils",
         "jsonlite",
         "jsonvalidate",
+        "methods",
         "purrr",
         "rlang",
-        "scoringutils (>= 2.0.0.9000)",
+        "scoringutils (>= 2.2.0)",
         "yaml"
       ],
-      "Remotes": "hubverse-org/hubData, hubverse-org/hubEvals, hubverse-org/hubUtils, epiforecasts/scoringutils",
+      "Additional_repositories": "https://hubverse-org.r-universe.dev",
       "Encoding": "UTF-8",
       "Roxygen": "list(markdown = TRUE)",
       "RoxygenNote": "7.3.3",
@@ -1675,11 +1676,11 @@
       "Config/pak/sysreqs": "cmake git make libicu-dev libuv1-dev libssl-dev libnode-dev libx11-dev",
       "Repository": "https://hubverse-org.r-universe.dev",
       "RemoteUrl": "https://github.com/hubverse-org/hubPredEvalsData",
-      "RemoteRef": "v1.0.0",
-      "RemoteSha": "76c08213a917f8582b613588bba8f315cbc2bdf7",
+      "RemoteRef": "v1.1.0",
+      "RemoteSha": "1d4a7f6e0c3a9d0bc853a3825b743badec172360",
       "NeedsCompilation": "no",
-      "Author": "Evan Ray [aut, cre]",
-      "Maintainer": "Evan Ray <elray@umass.edu>",
+      "Author": "Evan Ray [aut], Anna Krystalli [aut, cre] (ORCID: <https://orcid.org/0000-0002-2378-4915>)",
+      "Maintainer": "Anna Krystalli <annakrystalli@googlemail.com>",
       "Depends": [
         "R (>= 4.1.0)"
       ]

--- a/scripts/create-predevals-data.R
+++ b/scripts/create-predevals-data.R
@@ -5,28 +5,39 @@
 #
 # USAGE
 #
-#    create-predevals-data.R [--help] -h </path/to/hub> -c <cfg> -d <oracle> [-o <dir>]
+#    create-predevals-data.R [--help] -h </path/to/hub> -c <cfg> [-o <dir>] \
+#      [-d <oracle>] [--legacy-oracle-fallback <url>]
 #
 # ARGUMENTS
-# 
-#   --help             print help and exit
-#   -h </path/to/hub>  path to a local copy of the hub
-#   -c <cfg>           path or URL of predevals config file
-#   -d <oracle>        path or URL to oracle output data
-#   -o <dir>           output directory
-# 
+#
+#   --help                          print help and exit
+#   -h </path/to/hub>               path to a local copy of the hub
+#   -c <cfg>                        path or URL of predevals config file
+#   -o <dir>                        output directory
+#   -d <oracle>                     [DEPRECATED] path or URL to a single
+#                                   oracle-output file. When supplied, used
+#                                   directly and a deprecation warning is
+#                                   printed. When absent, oracle output is
+#                                   auto-discovered from <hub>/target-data/
+#                                   via hubData (supports CSV, parquet, and
+#                                   partitioned parquet per hubverse spec).
+#   --legacy-oracle-fallback <url>  [TRANSITIONAL] URL to read oracle output
+#                                   from if hubData auto-discovery fails.
+#                                   Intended for the control-room workflow's
+#                                   deprecation window. Will be removed once
+#                                   dashboards are migrated.
+#
 # EXAMPLE
 #
 # ```
-# prefix="https://raw.githubusercontent.com/elray1/flusight-dashboard/refs/heads"
+# prefix="https://raw.githubusercontent.com/hubverse-org/dashboard-test-hub-dashboard/refs/heads"
 # cfg="${prefix}/main/predevals-config.yml"
-# oracle="${prefix}/oracle-data/oracle-output.csv"
 # mkdir -p evals
 #
 # tmp=$(mktemp -d)
-# git clone https://github.com/cdcepi/FluSight-forecast-hub.git $tmp
+# git clone https://github.com/hubverse-org/dashboard-test-hub.git $tmp
 #
-# create-predevals-data.R -h $tmp -c $cfg -d $oracle -o evals
+# create-predevals-data.R -h $tmp -c $cfg -o evals
 # ```
 # DOC
 
@@ -34,7 +45,12 @@ args <- commandArgs()
 print_help <- function(script) {
   lines <- readLines(script)
   bookends <- which(lines == "# DOC")
-  writeLines(sub("# ?", "", lines[(bookends[1] + 1):(bookends[2] - 1)], perl = TRUE))
+  writeLines(sub(
+    "# ?",
+    "",
+    lines[(bookends[1] + 1):(bookends[2] - 1)],
+    perl = TRUE
+  ))
   quit(save = "no", status = 0)
 }
 
@@ -55,12 +71,8 @@ parse_args <- function(args, flag) {
 
 hub_path <- parse_args(args, "-h")
 predevals_config_path <- parse_args(args, "-c")
-oracle_output <- readr::read_csv(parse_args(args, "-d"))
-# Remove as_of column (it will cause errors downstream)
-# NOTE: we are assuming here that no hubs have a target called "as_of"
-if ("as_of" %in% names(oracle_output)) {
-  oracle_output <- oracle_output[setdiff(names(oracle_output), "as_of")]
-}
+oracle_path <- parse_args(args, "-d")
+legacy_oracle_fallback <- parse_args(args, "--legacy-oracle-fallback")
 output_dir <- parse_args(args, "-o")
 if (is.na(output_dir)) {
   output_dir <- getwd()
@@ -72,31 +84,82 @@ if (!dir.exists(out_path)) {
   dir.create(out_path)
 }
 
-hubPredEvalsData::generate_eval_data(hub_path, predevals_config_path, out_path, oracle_output)
-
-# create json objects used for initializing the dashboard
-# config <- hubPredEvalsData:::read_config(hub_path, predevals_config_path)
-config <- yaml::read_yaml(predevals_config_path)
-
-# update config with additional options
-# TODO: move this into a function in hubPredEvalsData
-predevals_options <- config
-predevals_options$targets <- purrr::map(
-  predevals_options$targets,
-  function(target) {
-    if (length(target$relative_metrics) > 0) {
-      target$metrics <- purrr::map(
-        target$metrics,
-        function(metric) {
-          if (metric %in% target$relative_metrics) {
-            return(c(paste0(metric, "_scaled_relative_skill"), metric))
-          } else {
-            return(metric)
-          }
-        }
-      ) |> unlist()
-    }
-    return(target)
+# Resolves oracle output via three paths, in priority order:
+#   1. -d <oracle>: explicit single-file path (deprecated, #35).
+#   2. hubData::connect_target_oracle_output(hub_path): default discovery.
+#   3. --legacy-oracle-fallback <url>: fallback when (2) fails (deprecated, #34).
+# When both deprecated options are removed (#34, #35), this function
+# disappears entirely: the orchestrator stops loading oracle output at all
+# and calls `generate_eval_data(hub_path, config_path, out_path)` without an
+# `oracle_output` argument, letting the package handle discovery internally
+# via `hubData::connect_target_oracle_output()`.
+resolve_oracle_output <- function(hub_path, oracle_path, legacy_fallback) {
+  if (length(oracle_path) > 0 && !is.na(oracle_path)) {
+    cat(
+      "WARNING: -d <oracle> is deprecated and will be removed in a future ",
+      "major release.\n",
+      "  Oracle output is now auto-discovered from <hub>/target-data/ via\n",
+      "  hubData::connect_target_oracle_output(), which supports CSV, ",
+      "parquet,\n",
+      "  and partitioned parquet per the hubverse spec. Drop -d to use it.\n",
+      sep = "",
+      file = stderr()
+    )
+    return(readr::read_csv(oracle_path))
   }
+  discovery <- tryCatch(
+    hubData::connect_target_oracle_output(hub_path) |> dplyr::collect(),
+    error = function(e) e
+  )
+  if (!inherits(discovery, "error")) {
+    return(discovery)
+  }
+  if (length(legacy_fallback) > 0 && !is.na(legacy_fallback)) {
+    cat(
+      "WARNING: hubData oracle discovery failed for hub_path=",
+      hub_path,
+      "\n",
+      "  Falling back to --legacy-oracle-fallback=",
+      legacy_fallback,
+      "\n",
+      "  Discovery error: ",
+      conditionMessage(discovery),
+      "\n",
+      "  This is a transitional fallback. The hub should publish oracle ",
+      "output per\n",
+      "  https://docs.hubverse.io/en/latest/user-guide/target-data.html\n",
+      sep = "",
+      file = stderr()
+    )
+    return(readr::read_csv(legacy_fallback))
+  }
+  # No -d, no fallback URL, and the hub publishes no recognised oracle output.
+  stop(
+    "Oracle output discovery failed for hub_path=",
+    hub_path,
+    ": ",
+    conditionMessage(discovery)
+  )
+}
+
+oracle_output <- resolve_oracle_output(
+  hub_path,
+  oracle_path,
+  legacy_oracle_fallback
+)
+
+# TODO(#35): drop `oracle_output` from this call (and delete
+# resolve_oracle_output()) once `-d` is removed; `generate_eval_data()`
+# discovers oracle internally via hubData.
+hubPredEvalsData::generate_eval_data(
+  hub_path,
+  predevals_config_path,
+  out_path,
+  oracle_output
+)
+
+predevals_options <- hubPredEvalsData::generate_predevals_options(
+  hub_path,
+  predevals_config_path
 )
 jsonlite::write_json(predevals_options, out_cfg, auto_unbox = TRUE)

--- a/tests/testthat/test-predevals-output.R
+++ b/tests/testthat/test-predevals-output.R
@@ -21,20 +21,27 @@ opts_path <- file.path(out_dir, "predevals-options.json")
 scores_root <- file.path(out_dir, "scores")
 
 # ---- Fixture expectations -------------------------------------------------
-# Pinned to:
-#   dashboard-test-hub @ main
-#   dashboard-test-hub-dashboard @ main
+# Pinned to (fixtures these expectations were derived from):
+#   dashboard-test-hub           @ 0a00609 (main, 2026-05-19)
+#   dashboard-test-hub-dashboard @ a5e5e30 (main, 2026-06-04)
 # Update tests if a change in either repo alters the pipeline output shape.
 
-# Metrics listed in predevals-options.json per target, after the
-# create-predevals-data.R rewrite that splices `_scaled_relative_skill`
-# entries in for any metric declared in `relative_metrics`.
+# Metrics listed in predevals-options.json per target. For transformable
+# metrics on targets that configure a `transform`, the transformed-scale
+# columns (`<metric>__<label>`) appear alongside the natural-scale ones.
+# For targets that also configure `relative_metrics`, `_scaled_relative_skill`
+# entries are spliced in; on a transformed target those carry their own
+# transformed-scale variants too.
 expected_metrics_by_target <- list(
   "wk inc flu hosp" = c(
     "wis_scaled_relative_skill",
+    "wis_scaled_relative_skill__log",
     "wis",
+    "wis__log",
     "ae_median_scaled_relative_skill",
+    "ae_median_scaled_relative_skill__log",
     "ae_median",
+    "ae_median__log",
     "interval_coverage_50",
     "interval_coverage_95"
   ),
@@ -47,7 +54,20 @@ expected_metrics_by_target <- list(
     "interval_coverage_95"
   ),
   "wk flu hosp rate category" = c(
-    "log_score"
+    "log_score",
+    "rps"
+  )
+)
+
+# Per-target `transform` block expected in predevals-options.json. Only
+# targets that configure a transform appear here; for all other targets
+# the `transform` field must be absent (NULL after JSON round-trip).
+expected_transform_by_target <- list(
+  "wk inc flu hosp" = list(
+    fun = "log_shift",
+    label = "log",
+    append = TRUE,
+    description = "Natural logarithm after adding an offset to the values (offset = 1)."
   )
 )
 
@@ -91,6 +111,26 @@ for (target_id in expected_targets) {
   })
 }
 
+# ---- transform block in predevals-options.json ----------------------------
+
+for (target_id in names(expected_transform_by_target)) {
+  test_that(sprintf("predevals-options.json transform block for '%s' matches expected", target_id), {
+    target <- Filter(function(x) x$target_id == target_id, opts$targets)[[1]]
+    expected <- expected_transform_by_target[[target_id]]
+    expect_equal(target$transform$fun, expected$fun)
+    expect_equal(target$transform$label, expected$label)
+    expect_equal(target$transform$append, expected$append)
+    expect_equal(target$transform$description, expected$description)
+  })
+}
+
+for (target_id in setdiff(expected_targets, names(expected_transform_by_target))) {
+  test_that(sprintf("predevals-options.json has no transform block for '%s'", target_id), {
+    target <- Filter(function(x) x$target_id == target_id, opts$targets)[[1]]
+    expect_null(target$transform)
+  })
+}
+
 # ---- scores.csv files -----------------------------------------------------
 
 for (fx in expected_files) {
@@ -104,8 +144,16 @@ for (fx in expected_files) {
   })
   if (!file.exists(full_path)) next
 
-  test_that(sprintf("[%s] is non-empty", rel_path), {
+  test_that(sprintf("[%s] is non-empty with expected columns", rel_path), {
     df <- readr::read_csv(full_path, show_col_types = FALSE, progress = FALSE)
     expect_gt(nrow(df), 0L)
+    by_col <- if (!is.null(fx$by)) fx$by else character(0)
+    expected_cols <- c(
+      "model_id",
+      by_col,
+      expected_metrics_by_target[[fx$target]],
+      "n"
+    )
+    expect_setequal(names(df), expected_cols)
   })
 }


### PR DESCRIPTION
## Summary

Refactor `scripts/create-predevals-data.R` into a thin orchestrator that delegates oracle discovery to `hubData` and `predevals-options.json` assembly to `hubPredEvalsData::generate_predevals_options()`. Bump `renv.lock` to `hubPredEvalsData` v1.1.0. Update the testthat fixtures to cover the new transform and rps features now available in the upstream package. Document the dev container workflows used to develop and verify the bump.

## Closes

- #6 (use hubData for oracle discovery)
- #22 (use `generate_predevals_options()`)
- #27 (update expected_* lists for v1.1.0 features)
- #33 (refresh renv.lock to pull hubPredEvalsData v1.1.0)

## What changes, and why

### 1. Orchestrator script (`scripts/create-predevals-data.R`)

Default behaviour now uses `hubData::connect_target_oracle_output(hub_path)` for oracle discovery, which supports CSV, parquet, and partitioned parquet per the [hubverse target-data spec](https://docs.hubverse.io/en/latest/user-guide/target-data.html). Side effect: the dashboard pipeline now correctly handles parquet hubs (e.g. `CDCgov/covid19-forecast-hub`), which the previous CSV-only probe in the control-room workflow silently excluded.

The inline `predevals-options.json` assembly block is replaced with a single call to `hubPredEvalsData::generate_predevals_options(hub_path, config_path)`, which adds transform metadata support (a `transform` block per target with `fun`/`label`/`append`/`description`) and folds transformed-scale `<metric>__<label>` columns into the `metrics` list alongside natural-scale entries. Reviewed and merged upstream in [hubverse-org/hubPredEvalsData#60](https://github.com/hubverse-org/hubPredEvalsData/pull/60).

Two back-compatibility flags, intentionally separate:

| Flag | Audience | Lifecycle | Tracking |
|---|---|---|---|
| `-d <oracle>` | Human callers using the documented README invocation. Single file path only via `readr::read_csv`. Emits loud stderr deprecation warning. | Removed in a future docker major. | #35 |
| `--legacy-oracle-fallback <url>` | The control-room workflow's deprecation window. Used only if hubData discovery fails; emits a different warning targeted at dashboard owners. | Removed after dashboards migrate. | #34 |

**Why two flags rather than overloading `-d`:**

1. **Independent removal.** `grep` `legacy-oracle-fallback`, delete those branches, done. No risk to `-d` callers.
2. **Self-documenting.** The flag name literally says "this is the legacy migration shim". Workflow yaml is readable.
3. **Different warning messages for different audiences.** `-d` warning is *"drop this to use auto-discovery"*; fallback warning is *"your hub does not publish oracle at any recognized location, migrate per spec"*. Both can be tuned to their actual reader.
4. **Cleaner script semantics.** `-d` means "use this directly"; `--legacy-oracle-fallback` means "use this only if discovery fails". Overloading would muddy the precedence rules.

When both deprecations land (#34, #35), `resolve_oracle_output()` disappears entirely and the orchestrator stops loading oracle at all. `generate_eval_data()` does its own discovery via hubData per [hubverse-org/hubPredEvalsData#51](https://github.com/hubverse-org/hubPredEvalsData/issues/51) (shipped in v1.1.0). The TODO at the call site flags this.

### 2. CI workflow updates

`chain-build.yaml` and `publish-production.yaml` invoke `create-predevals-data.R` without `-d`, exercising the new hubData-discovery default in CI rather than the deprecated option. Production-image consumers using `-d` are unaffected (the back-compat option is preserved with a warning).

### 3. `renv.lock` refresh

Bumps `hubPredEvalsData` from 1.0.0 to 1.1.0 (single-package change, no transitive churn). v1.1.0 provides both `generate_predevals_options()` and the `oracle_output = NULL` default for `generate_eval_data()` that the orchestrator depends on.

Verified end-to-end in a persistent dev container using the documented "Update + verify + explore" pattern: pipeline runs cleanly with default hubData discovery, testthat 56/56 pass.

### 4. README: dev-container workflow documentation

Restructures the "Updating `renv.lock`" section into three goal-oriented patterns, with a quick-reference table at the top:

- **Just update (ephemeral)**: existing pattern, throws away container cache.
- **Update + verify (ephemeral, one-shot)**: single `docker run` that updates the lockfile, stages the canonical test fixture, runs the pipeline, and runs testthat. Good for routine PRs.
- **Update + verify + explore (persistent)**: persistent container with project mounted, supports iterating without re-installing packages between passes.

Clarifies the existing "Ephemeral dev testing" section opening to make clear it covers a different goal: smoke-testing dev versions of upstream packages without modifying the host `renv.lock`.

Filed [#38](https://github.com/hubverse-org/hubPredEvalsData-docker/issues/38) for the optional ergonomic improvement of wrapping the verify chain into a small helper script.

### 5. Updated testthat fixtures (`tests/testthat/test-predevals-output.R`)

`dashboard-test-hub-dashboard@main` now configures a `log_shift` transform on `wk inc flu hosp` (via [hubverse-org/dashboard-test-hub-dashboard#3](https://github.com/hubverse-org/dashboard-test-hub-dashboard/pull/3)) and adds `rps` to `wk flu hosp rate category` (via [hubverse-org/dashboard-test-hub-dashboard#7](https://github.com/hubverse-org/dashboard-test-hub-dashboard/pull/7)). The testthat fixtures here are extended to match:

- `expected_metrics_by_target` extended for both targets. `wk inc flu hosp` gains `<metric>__log` columns (transformed-scale) spliced beside each natural-scale entry, including the relative-skill variants. `wk flu hosp rate category` gains `rps` (now scored cleanly thanks to [hubverse-org/hubPredEvalsData#48](https://github.com/hubverse-org/hubPredEvalsData/issues/48) in v1.1.0).
- New `expected_transform_by_target` plus per-target assertions on the `transform` block in `predevals-options.json`: expected `fun`/`label`/`append`/`description` shape on transformed targets, absent (NULL) on the rest. Mirrors hubPredEvalsData's own expected-options fixtures.
- New strict column-set assertion on every `scores.csv`: each file's columns must be exactly `model_id`, `<by>` (if disaggregated), the expected metrics, `n`. Catches drift between `predevals-options.json`'s declared metrics and the actual `scores.csv` columns predevals JS will read.
- Header pins the fixture commit SHAs so future readers know which `dashboard-test-hub` and `dashboard-test-hub-dashboard` state these expectations were derived from.

The `is non-empty` and `expected columns` assertions on each `scores.csv` are consolidated into a single `test_that` block to read each file once instead of twice.

### 6. Documentation polish

- README intro now mentions both functions wrapped by the container (was a `generate_evals_data` typo, also missing `generate_predevals_options`).
- Usage section explicitly frames the two contexts (CI via control-room vs local docker run) with links to the corresponding hubverse docs pages.
- Help block and Example synced to the new arg surface (no `-d` in primary examples; deprecated annotation on the flag).
- Example switched from external (elray1 / cdcepi) refs to the `dashboard-test-hub` fixture used in CI.

## Verification

Run in the dev container against `hubverse-org/dashboard-test-hub` + `hubverse-org/dashboard-test-hub-dashboard` with `renv.lock` pinned to `hubPredEvalsData` v1.1.0:

- **Default invocation** (no `-d`): script completes, produces 16 output files (15 `scores.csv` + `predevals-options.json`).
- **`-d <oracle-csv>` shim**: deprecation WARNING fires on stderr; output is content-identical to the default path (verified earlier in the dev cycle).
- **testthat**: 56/56 pass against the current fixture state (`dashboard-test-hub@0a00609` + `dashboard-test-hub-dashboard@a5e5e30`).
- Host `renv.lock` only modified intentionally via `update.R` (verified clean working tree between steps).

## Cross-links and follow-ups

- **Upstream (hubPredEvalsData)**: [v1.1.0 release](https://github.com/hubverse-org/hubPredEvalsData/issues/62) (shipped), [generate_predevals_options PR](https://github.com/hubverse-org/hubPredEvalsData/pull/60) (merged into v1.1.0), [internal oracle discovery](https://github.com/hubverse-org/hubPredEvalsData/issues/51) (merged into v1.1.0).
- **Downstream (hub-dashboard-control-room)**: [#108](https://github.com/hubverse-org/hub-dashboard-control-room/issues/108) (dashboard pipeline migration plan), [#109](https://github.com/hubverse-org/hub-dashboard-control-room/pull/109) (workflow migration PR, depends on this PR merging + #37 publishing).
- **Fixture (dashboard-test-hub-dashboard)**: [#3](https://github.com/hubverse-org/dashboard-test-hub-dashboard/pull/3) (transform config, merged), [#7](https://github.com/hubverse-org/dashboard-test-hub-dashboard/pull/7) (rps config, merged).
- **Future deprecation removals**: #34 (`--legacy-oracle-fallback`), #35 (`-d`).
- **Future ergonomics**: #38 (helper script for the update + verify one-shot pattern).
- **Release sequence after this merges**: #37 (cut `v1.1.0` docker tag, publish-production runs, `:latest` carries v1.1.0), then control-room#109 is unblocked.