### PR TITLE
Finalise v1.1.0 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubPredEvalsDataDocker
 Title: Docker Wrapper for hubPredEvalsData
-Version: 1.0.1.9000
+Version: 1.1.0
 Description: Declares dependencies for the hubPredEvalsData Docker container.
     This file enables renv to use explicit snapshot type for reproducible
     dependency management.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubPredEvalsData-docker (development version)
+# hubPredEvalsData-docker 1.1.0
 
 ## Orchestrator script
 


### PR DESCRIPTION
Release-prep for the `v1.1.0` production image tag (steps 1-3 of #37).

## Changes
- Bump `DESCRIPTION` `Version:` from `1.0.1.9000` to `1.1.0`. Minor bump: the orchestrator gains hubData oracle discovery as the default and a new `--legacy-oracle-fallback` flag, with `-d` retained as a back-compatibility option. No breaking changes to existing callers.
- Finalise `NEWS.md`: replace the `(development version)` heading with `# hubPredEvalsData-docker 1.1.0`. All entries since the last release are captured (orchestrator from #36, production/base+dev image work, CI workflows, docs).

## Next
Once merged, a signed `v1.1.0` tag on `main` triggers `publish-production.yaml` to build and push the image to GHCR `:latest` (#37).