### PR TITLE
Post-release: set development version (1.1.0.9000)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubPredEvalsDataDocker
 Title: Docker Wrapper for hubPredEvalsData
-Version: 1.1.0
+Version: 1.1.0.9000
 Description: Declares dependencies for the hubPredEvalsData Docker container.
     This file enables renv to use explicit snapshot type for reproducible
     dependency management.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubPredEvalsData-docker (development version)
+
 # hubPredEvalsData-docker 1.1.0
 
 ## Orchestrator script


### PR DESCRIPTION
Post-release bump following the v1.1.0 release.

- Set `DESCRIPTION` `Version:` to `1.1.0.9000`.
- Add a fresh `(development version)` heading to `NEWS.md` above the `1.1.0` section.

Restores the development state of `main` now that v1.1.0 is tagged and published to GHCR. Mirrors `usethis::use_dev_version()` (run manually as `usethis` is not in the project renv).