### PR TITLE
Post-release: set development version (1.2.0.9000)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubPredEvalsDataDocker
 Title: Docker Wrapper for hubPredEvalsData
-Version: 1.2.0
+Version: 1.2.0.9000
 Description: Declares dependencies for the hubPredEvalsData Docker container.
     This file enables renv to use explicit snapshot type for reproducible
     dependency management.


### PR DESCRIPTION
Sets `DESCRIPTION` to `1.2.0.9000` following the v1.2.0 release.

`NEWS.md` already carries a `(development version)` heading, so it needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)